### PR TITLE
WIP: To enrich NIDM-E with attributes from T1w.json and task-rest_bold.json files 

### DIFF
--- a/nidm/experiment/Core.py
+++ b/nidm/experiment/Core.py
@@ -315,13 +315,13 @@ class Core(object):
 
 
 
-        #context2 = self.prefix_to_context()
-
-        #context = dict(context1,**context2)
-        #context = context2
-
-        context=self.createDefaultJSONLDcontext()
-
+        #WIP: currently this creates a default JSON-LD context from Constants.py and not in the correct way from the
+        #NIDM-E OWL files that that will be the next iteration
+        context1 = self.createDefaultJSONLDcontext()
+        #This part adds to the context any prefixes in an existing NIDM-E file that might have been added by a user
+        #and isn't covered by the default namespaces / constants in Constants.py
+        context2 = self.prefix_to_context()
+        context = dict(context1, **context2)
 
         #WIP: LOOK AT https://github.com/satra/nidm-jsonld
         #return rdf_graph_parse.serialize(format='json-ld', context=context, indent=4).decode('ASCII')
@@ -343,13 +343,6 @@ class Core(object):
 
         context={}
 
-        #some initial entries
-        #context['@context'] = OrderedDict()
-        #context['@context']['@version'] = "1.1"
-        #context['@context']['records'] = OrderedDict()
-        #context['@context']['records']['@container'] = "@type"
-        #context['@context']['records']['@id'] = "@graph"
-
 
         context['@version'] = 1.1
         context['records'] = {}
@@ -357,27 +350,8 @@ class Core(object):
         context['records']['@id'] = "@graph"
 
         #load Constants.namespaces
-
-        #add namespaces in Constants to context
-        #context['@context'].update(Constants.namespaces)
         context.update(Constants.namespaces)
 
-        #add some prov stuff
-        #context['@context'].update = {
-        #    "xsd": {"@type": "@id","@id":"http://www.w3.org/2001/XMLSchema#"},
-        #    "prov": {"@type": "@id","@id":"http://www.w3.org/ns/prov#"},
-        #    "agent": { "@type": "@id", "@id": "prov:agent" },
-        #    "entity": { "@type": "@id", "@id": "prov:entity" },
-        #    "activity": { "@type": "@id", "@id": "prov:activity" },
-        #    "hadPlan": { "@type": "@id", "@id": "prov:hadPlan" },
-        #    "hadRole": { "@type": "@id", "@id": "prov:hadRole" },
-        #    "wasAttributedTo": { "@type": "@id", "@id": "prov:wasAttributedTo" },
-        #    "association": { "@type": "@id", "@id": "prov:qualifiedAssociation" },
-        #    "usage": { "@type": "@id", "@id": "prov:qualifiedUsage" },
-        #    "generation": { "@type": "@id", "@id": "prov:qualifiedGeneration" },
-        #    "startedAtTime": { "@type": "xsd:dateTime", "@id": "prov:startedAtTime" },
-        #    "endedAtTime": { "@type": "xsd:dateTime", "@id": "prov:endedAtTime" },
-        #}
         context.update ({
             "xsd": {"@type": "@id","@id":"http://www.w3.org/2001/XMLSchema#"},
             "prov": {"@type": "@id","@id":"http://www.w3.org/ns/prov#"},
@@ -408,8 +382,8 @@ class Core(object):
 
         #add prefix's from current document...this accounts for new terms
         context.update ( self.prefix_to_context() )
-        #test=self.prefix_to_context()
 
+        #WIP
         #cycle through OWL graph and add terms
         # For anything that has a label
 
@@ -425,7 +399,6 @@ class Core(object):
         #    else:
         #        context['@context'][json_key] = str(s)
 
-        #print(json.dumps(context, indent=2))
         return context
 
     def save_DotGraph(self,filename,format=None):

--- a/nidm/experiment/Core.py
+++ b/nidm/experiment/Core.py
@@ -322,7 +322,7 @@ class Core(object):
 
         context=self.createDefaultJSONLDcontext()
 
-        
+
         #WIP: LOOK AT https://github.com/satra/nidm-jsonld
         #return rdf_graph_parse.serialize(format='json-ld', context=context, indent=4).decode('ASCII')
         g=rdf_graph_parse.serialize(format='json-ld', indent=4).decode('ASCII')

--- a/nidm/experiment/Core.py
+++ b/nidm/experiment/Core.py
@@ -322,11 +322,12 @@ class Core(object):
 
         context=self.createDefaultJSONLDcontext()
 
+        
         #WIP: LOOK AT https://github.com/satra/nidm-jsonld
         #return rdf_graph_parse.serialize(format='json-ld', context=context, indent=4).decode('ASCII')
-        g=rdf_graph_parse.serialize(format='json-ld', context=context, indent=4).decode('ASCII')
+        g=rdf_graph_parse.serialize(format='json-ld', indent=4).decode('ASCII')
         import pyld as ld
-        return ld.jsonld.compact(json.loads(g), context)
+        return json.dumps(ld.jsonld.compact(json.loads(g), context),indent=4)
 
     def createDefaultJSONLDcontext(self):
         '''
@@ -350,7 +351,7 @@ class Core(object):
         #context['@context']['records']['@id'] = "@graph"
 
 
-        context['@version'] = "1.1"
+        context['@version'] = 1.1
         context['records'] = {}
         context['records']['@container'] = "@type"
         context['records']['@id'] = "@graph"

--- a/nidm/experiment/Core.py
+++ b/nidm/experiment/Core.py
@@ -321,8 +321,12 @@ class Core(object):
         #context = context2
 
         context=self.createDefaultJSONLDcontext()
+
         #WIP: LOOK AT https://github.com/satra/nidm-jsonld
-        return rdf_graph_parse.serialize(format='json-ld', context=context, indent=4).decode('ASCII')
+        #return rdf_graph_parse.serialize(format='json-ld', context=context, indent=4).decode('ASCII')
+        g=rdf_graph_parse.serialize(format='json-ld', context=context, indent=4).decode('ASCII')
+        import pyld as ld
+        return ld.jsonld.compact(json.loads(g), context)
 
     def createDefaultJSONLDcontext(self):
         '''
@@ -403,7 +407,8 @@ class Core(object):
 
         #add prefix's from current document...this accounts for new terms
         context.update ( self.prefix_to_context() )
-        test=self.prefix_to_context()
+        #test=self.prefix_to_context()
+
         #cycle through OWL graph and add terms
         # For anything that has a label
 
@@ -419,7 +424,7 @@ class Core(object):
         #    else:
         #        context['@context'][json_key] = str(s)
 
-        print(json.dumps(context, indent=2))
+        #print(json.dumps(context, indent=2))
         return context
 
     def save_DotGraph(self,filename,format=None):

--- a/nidm/experiment/tools/BIDSMRI2NIDM.py
+++ b/nidm/experiment/tools/BIDSMRI2NIDM.py
@@ -216,7 +216,6 @@ def bidsmri2project(directory, args):
         #add absolute location of BIDS directory on disk for later finding of files which are stored relatively in NIDM document
         project.add_attributes({Constants.PROV['Location']:directory})
 
-
     #get BIDS layout
     bids_layout = BIDSLayout(directory)
 
@@ -279,7 +278,7 @@ def bidsmri2project(directory, args):
 
                 #add qualified association of participant with acquisition activity
                 acq.add_qualified_association(person=participant[subjid]['person'],role=Constants.NIDM_PARTICIPANT)
-
+                print(acq)
 
 
                 for key,value in row.items():
@@ -365,6 +364,7 @@ def bidsmri2project(directory, args):
                 else:
                     logging.info("WARNINGL file %s doesn't exist! No SHA512 sum stored in NIDM files..." %join(directory,file_tpl.dirname,file_tpl.filename))
                 #get associated JSON file if exists
+                #There is T1w.json file with information 
                 json_data = (bids_layout.get(suffix=file_tpl.entities['suffix'],subject=subject_id))[0].metadata
                 if len(json_data.info)>0:
                     for key in json_data.info.items():
@@ -373,6 +373,28 @@ def bidsmri2project(directory, args):
                                 acq_obj.add_attributes({BIDS_Constants.json_keys[key.replace(" ", "_")]:''.join(str(e) for e in json_data.info[key])})
                             else:
                                 acq_obj.add_attributes({BIDS_Constants.json_keys[key.replace(" ", "_")]:json_data.info[key]})
+                   
+                #Parse T1w.json file in BIDS directory to add the attributes contained inside
+                if (os.path.isdir(os.path.join(directory))):
+                    try:
+                        with open(os.path.join(directory,'T1w.json')) as data_file:
+                            dataset = json.load(data_file)
+                    except OSError:
+                        logging.critical("Cannot find T1w.json file which is required in the BIDS spec")
+                        exit("-1")
+                else:
+                    logging.critical("Error: BIDS directory %s does not exist!" %os.path.join(directory))
+                    exit("-1")
+
+                #add various attributes if they exist in BIDS dataset
+                for key in dataset:
+                    #if key from T1w.json file is mapped to term in BIDS_Constants.py then add to NIDM object
+                    if key in BIDS_Constants.json_keys:
+                        if type(dataset[key]) is list:
+                            acq_obj.add_attributes({BIDS_Constants.json_keys[key]:"".join(dataset[key])})
+                        else:
+                            acq_obj.add_attributes({BIDS_Constants.json_keys[key]:dataset[key]}) 
+                                                          
             elif file_tpl.entities['datatype'] == 'func':
                 #do something with functionals
                 acq_obj = MRObject(acq)
@@ -422,6 +444,27 @@ def bidsmri2project(directory, args):
                     events_obj.add_attributes({PROV_TYPE:Constants.NIDM_MRI_BOLD_EVENTS,BIDS_Constants.json_keys["TaskName"]: json_data["TaskName"], Constants.NIDM_FILENAME:getRelPathToBIDS(events_file[0].filename, directory)})
                     #link it to appropriate MR acquisition entity
                     events_obj.wasAttributedTo(acq_obj)
+                    
+                #Parse task-rest_bold.json file in BIDS directory to add the attributes contained inside
+                if (os.path.isdir(os.path.join(directory))):
+                    try:
+                        with open(os.path.join(directory,'task-rest_bold.json')) as data_file:
+                            dataset = json.load(data_file)
+                    except OSError:
+                        logging.critical("Cannot find task-rest_bold.json file which is required in the BIDS spec")
+                        exit("-1")
+                else:
+                    logging.critical("Error: BIDS directory %s does not exist!" %os.path.join(directory))
+                    exit("-1")
+
+                #add various attributes if they exist in BIDS dataset
+                for key in dataset:
+                    #if key from task-rest_bold.json file is mapped to term in BIDS_Constants.py then add to NIDM object
+                    if key in BIDS_Constants.json_keys:
+                        if type(dataset[key]) is list:
+                            acq_obj.add_attributes({BIDS_Constants.json_keys[key]:",".join(map(str,dataset[key]))})
+                        else:
+                            acq_obj.add_attributes({BIDS_Constants.json_keys[key]:dataset[key]}) 
 
             elif file_tpl.entities['datatype'] == 'dwi':
                 #do stuff with with dwi scans...

--- a/nidm/version.py
+++ b/nidm/version.py
@@ -58,5 +58,5 @@ VERSION = __version__
 #REQUIRES = ["prov", "rdflib", "graphviz", "pydotplus", "pydot", "validators", "requests", "fuzzywuzzy", "pygithub",
 #            "pandas", "pybids", "duecredit", "pytest", "graphviz", "click", "ontquery"]
 INSTALL_REQUIRES = ["prov", "rdflib", "graphviz", "pydotplus", "pydot", "validators", "requests", "fuzzywuzzy", "pygithub",
-            "pandas", "pybids", "duecredit", "pytest", "graphviz", "click", "ontquery","rdflib-jsonld"]
+            "pandas", "pybids", "duecredit", "pytest", "graphviz", "click", "ontquery","rdflib-jsonld","pyld"]
 SCRIPTS = ["bin/nidm_query", "bin/BIDSMRI2NIDM", "bin/CSV2NIDM","bin/nidm_utils"]


### PR DESCRIPTION
I try to compare what is done using https://github.com/dbkeator/PyNIDM/blob/master/nidm/experiment/tools/nidm_utils.py and https://github.com/dbkeator/PyNIDM/blob/master/nidm/experiment/tools/BIDSMRI2NIDM.py. Indeed, **nidms_utils** converts NIDM-experiment (ttl) → NIDM-experiment (json -ld) while **bidsmri2nidm** converts bids → NIDM-Experiment. However, even if the json documents obtained should be equal, there are some differences. For instance, the information in T1w.json file and task-rest_bold.json ( here from abide datalad dataset, CMU_a bids site) are not exploited. 
Hence, I added a few lines (376-397 and 447-467) in order to take advantages of these attributes. 
 
