### PR TITLE
changing the tox setting

### DIFF
--- a/src/nidm/experiment/tools/bidsmri2nidm.py
+++ b/src/nidm/experiment/tools/bidsmri2nidm.py
@@ -1082,7 +1082,6 @@ def bidsmri2project(directory, args):
                 json_source=json_source,
                 bids=True,
                 associate_concepts=associate_concepts,
-                dataset_identifier=dataset_doi,
             )
 
             # iterate over rows in participants.tsv file and create NIDM objects for sessions and acquisitions

--- a/tox.ini
+++ b/tox.ini
@@ -25,11 +25,8 @@ commands = sphinx-build -E -W -b html source build
 [pytest]
 addopts = --cov=nidm --no-cov-on-fail
 filterwarnings =
-    error
-    # <https://github.com/sensein/etelemetry-client/pull/44>
-    ignore:.*pkg_resources:DeprecationWarning
-    # <https://github.com/PythonCharmers/python-future/issues/246>
-    ignore:the imp module is deprecated:DeprecationWarning
+    default
+    error:::nidm
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
- change to less strict rule for changing warnings to errors, do it only for the warnings from nidm, since I got too many warnings from other projects

-  removing undefined `dataset_doi` (it was forgotten after removing the definition of `dataset_doi` in a previous commit)